### PR TITLE
Only auto flow based on settled transfers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,18 @@ The `connection_config` map contains various configuration properties.
 -type connection_config() ::
     #{container_id => binary(), % mandatory
       address => inet:socket_address() | inet:hostname(), % mandatory
-      hostname => binary(), % required by some brokers such as Azure ServiceBus
       port => inet:port_number(), % mandatory
+      % the dns name of the target host
+      % required by some vendors such as Azure ServiceBus
+      hostname => binary(),
       tls_opts => {secure_port, [ssl:ssl_option()]}, % optional
       notify => pid(), % Pid to receive protocol notifications. Set to self() if not provided
       max_frame_size => non_neg_integer(), % incoming max frame size
       idle_time_out => non_neg_integer(), % heartbeat
-      sasl => none | anon | {plain, User :: binary(), Password :: binary()}
+      sasl => none | anon | {plain, User :: binary(), Password :: binary(),
+      % set this to a negative value to allow a sender to "overshoot" the flow
+      % control by this margin
+      transfer_limit_margin => 0 | neg_integer()}
   }.
 
 ```

--- a/src/amqp10_client.erl
+++ b/src/amqp10_client.erl
@@ -352,6 +352,8 @@ parse_result({Scheme, UserInfo, Host, Port, "/", Query0}) ->
                              Acc#{max_frame_size => list_to_integer(V)};
                         ("hostname", V, Acc) ->
                              Acc#{hostname => list_to_binary(V)};
+                        ("transfer_limit_margin", V, Acc) ->
+                             Acc#{transfer_limit_margin => list_to_integer(V)};
                         (_, _, Acc) -> Acc
                      end, #{address => Host,
                             port => Port,

--- a/src/amqp10_client_connection.erl
+++ b/src/amqp10_client_connection.erl
@@ -62,6 +62,9 @@
       max_frame_size => non_neg_integer(), % TODO: constrain to large than 512
       outgoing_max_frame_size => non_neg_integer() | undefined,
       idle_time_out => non_neg_integer(),
+      % set to a negative value to allow a sender to "overshoot" the flow
+      % control by this margin
+      transfer_limit_margin => integer(),
       sasl => none | anon | {plain, User :: binary(), Pwd :: binary()}
   }.
 
@@ -449,4 +452,5 @@ sasl_to_bin({plain, _, _}) -> <<"PLAIN">>;
 sasl_to_bin(anon) -> <<"ANONYMOUS">>.
 
 config_defaults() ->
-    #{sasl => none}.
+    #{sasl => none,
+      transfer_limit_margin => 0}.

--- a/src/amqp10_client_connection.erl
+++ b/src/amqp10_client_connection.erl
@@ -52,19 +52,21 @@
 
 -type amqp10_socket() :: {tcp, gen_tcp:socket()} | {ssl, ssl:socket()}.
 
+-type milliseconds() :: non_neg_integer().
+
 -type connection_config() ::
-    #{container_id => binary(),
+    #{container_id => binary(), % AMQP container id
+      hostname => binary(), % the dns name of the target host
       address => inet:socket_address() | inet:hostname(),
-      hostname => binary(),
       port => inet:port_number(),
       tls_opts => {secure_port, [ssl:ssl_option()]},
-      notify => pid(),
+      notify => pid(), % the pid to send connection events to
       max_frame_size => non_neg_integer(), % TODO: constrain to large than 512
       outgoing_max_frame_size => non_neg_integer() | undefined,
-      idle_time_out => non_neg_integer(),
+      idle_time_out => milliseconds(),
       % set to a negative value to allow a sender to "overshoot" the flow
       % control by this margin
-      transfer_limit_margin => integer(),
+      transfer_limit_margin => 0 | neg_integer(),
       sasl => none | anon | {plain, User :: binary(), Pwd :: binary()}
   }.
 


### PR DESCRIPTION
Previously we'd auto flow more credit to sender after a certain number
of received transfer whether they have been settled or not. This changes
the approach to keep a separate counter of transfers that have been
settled and only grant more credit once this falls below the requested
limit. It isn't a perfect approach but it is much better than what was
there before which would effectively have the effect of providing no
flow control.