### PR TITLE
Handle transfer frames without deliver_id

### DIFF
--- a/src/amqp10_client_session.erl
+++ b/src/amqp10_client_session.erl
@@ -348,7 +348,7 @@ mapped({#'v1_0.transfer'{handle = {uint, InHandle},
               State0#state{links = Links#{OutHandle => Link1}}),
     {next_state, mapped, State};
 mapped({#'v1_0.transfer'{handle = {uint, InHandle},
-                         delivery_id = {uint, DeliveryId},
+                         delivery_id = MaybeDeliveryId,
                          settled = Settled} = Transfer0, Payload0},
                          #state{incoming_unsettled = Unsettled0} = State0) ->
 
@@ -359,10 +359,13 @@ mapped({#'v1_0.transfer'{handle = {uint, InHandle},
 
     {Transfer, Payload} = complete_partial_transfer(Transfer0, Payload0, Link),
     Msg = decode_as_msg(Transfer, Payload),
+
     % stash the DeliveryId - not sure for what yet
-    Unsettled = case Settled of
-                   true -> Unsettled0;
-                   _ -> Unsettled0#{DeliveryId => OutHandle}
+    Unsettled = case MaybeDeliveryId of
+                    {uint, DeliveryId} when Settled =/= true ->
+                        Unsettled0#{DeliveryId => OutHandle};
+                    _ ->
+                        Unsettled0
                 end,
 
     % link bookkeeping

--- a/test/mock_server.erl
+++ b/test/mock_server.erl
@@ -71,6 +71,11 @@ amqp_step(Fun) ->
             ct:pal("AMQP Step receieved ~p~n", [Recv]),
             case Fun(Recv) of
                 {_Ch, []} -> ok;
+                {Ch, {multi, Records}} ->
+                    [begin
+                         ct:pal("AMQP multi Step send ~p~n", [R]),
+                         send(Sock, Ch, R)
+                     end || R <- Records];
                 {Ch, Records} ->
                     ct:pal("AMQP Step send ~p~n", [Records]),
                     send(Sock, Ch, Records)
@@ -84,5 +89,5 @@ send_amqp_header_step(Sock) ->
 
 recv_amqp_header_step(Sock) ->
     ct:pal("Receiving AMQP protocol header"),
-    R = gen_tcp:recv(Sock, 8),
+    {ok, R} = gen_tcp:recv(Sock, 8),
     ct:pal("handshake Step receieved ~p~n", [R]).

--- a/test/system_SUITE.erl
+++ b/test/system_SUITE.erl
@@ -44,7 +44,8 @@ all() ->
      {group, rabbitmq},
      {group, rabbitmq_strict},
      {group, activemq},
-     {group, activemq_no_anon}
+     {group, activemq_no_anon},
+     {group, mock}
     ].
 
 groups() ->
@@ -69,7 +70,8 @@ groups() ->
       ]},
      {mock, [], [
                  insufficient_credit,
-                 incoming_heartbeat
+                 incoming_heartbeat,
+                 multi_transfer_without_delivery_id
                 ]}
     ].
 
@@ -147,8 +149,9 @@ init_per_group(azure, Config) ->
                                          {sb_port, 5671}
                                         ]);
 init_per_group(mock, Config) ->
-    rabbit_ct_helpers:set_config(Config, [{mock_port, 21000},
-                                          {mock_host, "localhost"}
+    rabbit_ct_helpers:set_config(Config, [{mock_port, 25000},
+                                          {mock_host, "localhost"},
+                                          {sasl, none}
                                          ]).
 end_per_group(rabbitmq, Config) ->
     rabbit_ct_helpers:run_steps(Config, rabbit_ct_broker_helpers:teardown_steps());
@@ -495,6 +498,7 @@ insufficient_credit(Config) ->
     {ok, Session} = amqp10_client:begin_session_sync(Connection),
     {ok, Sender} = amqp10_client:attach_sender_link(Session, <<"mock1-sender">>,
                                                     <<"test">>),
+    await_link(Sender, attached, attached_timeout),
     Msg = amqp10_msg:new(<<"mock-tag">>, <<"banana">>, true),
     {error, insufficient_credit} = amqp10_client:send_msg(Sender, Msg),
 
@@ -502,6 +506,68 @@ insufficient_credit(Config) ->
     ok = amqp10_client:close_connection(Connection),
     ok.
 
+multi_transfer_without_delivery_id(Config) ->
+    Hostname = ?config(mock_host, Config),
+    Port = ?config(mock_port, Config),
+    OpenStep = fun({0 = Ch, #'v1_0.open'{}, _Pay}) ->
+                       {Ch, [#'v1_0.open'{container_id = {utf8, <<"mock">>}}]}
+               end,
+    BeginStep = fun({1 = Ch, #'v1_0.begin'{}, _Pay}) ->
+                         {Ch, [#'v1_0.begin'{remote_channel = {ushort, 1},
+                                             next_outgoing_id = {uint, 1},
+                                             incoming_window = {uint, 1000},
+                                             outgoing_window = {uint, 1000}}
+                                             ]}
+                end,
+    AttachStep = fun({1 = Ch, #'v1_0.attach'{role = true,
+                                             name = Name}, <<>>}) ->
+                         {Ch, [#'v1_0.attach'{name = Name,
+                                              handle = {uint, 99},
+                                              initial_delivery_count = {uint, 1},
+                                              role = false}
+                              ]}
+                 end,
+
+    LinkCreditStep = fun({1 = Ch, #'v1_0.flow'{}, <<>>}) ->
+                             {Ch, {multi, [[#'v1_0.transfer'{handle = {uint, 99},
+                                                             delivery_id = {uint, 12},
+                                                             more = true},
+                                            #'v1_0.data'{content = <<"hello ">>}],
+                                           [#'v1_0.transfer'{handle = {uint, 99},
+                                                             % delivery_id can be omitted
+                                                             % for continuation frames
+                                                             delivery_id = undefined,
+                                                             settled = true,
+                                                             more = false},
+                                            #'v1_0.data'{content = <<"world">>}]
+                                          ]}}
+                     end,
+    Steps = [fun mock_server:recv_amqp_header_step/1,
+             fun mock_server:send_amqp_header_step/1,
+             mock_server:amqp_step(OpenStep),
+             mock_server:amqp_step(BeginStep),
+             mock_server:amqp_step(AttachStep),
+             mock_server:amqp_step(LinkCreditStep)
+            ],
+
+    ok = mock_server:set_steps(?config(mock_server, Config), Steps),
+
+    Cfg = #{address => Hostname, port => Port, sasl => none, notify => self()},
+    {ok, Connection} = amqp10_client:open_connection(Cfg),
+    {ok, Session} = amqp10_client:begin_session_sync(Connection),
+    {ok, Receiver} = amqp10_client:attach_receiver_link(Session, <<"mock1-received">>,
+                                                    <<"test">>),
+    amqp10_client:flow_link_credit(Receiver, 100, 50),
+    receive
+        {amqp10_msg, Receiver, _InMsg} ->
+            ok
+    after 2000 ->
+              exit(delivery_timeout)
+    end,
+
+    ok = amqp10_client:end_session(Session),
+    ok = amqp10_client:close_connection(Connection),
+    ok.
 
 outgoing_heartbeat(Config) ->
     Hostname = ?config(rmq_hostname, Config),
@@ -550,7 +616,10 @@ incoming_heartbeat(Config) ->
 %%%
 
 receive_messages(Receiver, Num) ->
-    [ok = receive_one(Receiver) || _T <- lists:seq(1, Num)].
+    [begin
+         ct:pal("receive_messages ~p", [T]),
+         ok = receive_one(Receiver)
+     end || T <- lists:seq(1, Num)].
 
 publish_messages(Sender, Data, Num) ->
     [begin


### PR DESCRIPTION
Fixes bug where continuation frames without a delivery_id were not
handled.

Also re-enables tests using the mock server.

Fixes: #11 

[#153702031]