### PR TITLE
Add test for large message sizes.

### DIFF
--- a/src/amqp10_client.hrl
+++ b/src/amqp10_client.hrl
@@ -17,7 +17,7 @@
 -define(AMQP_PROTOCOL_HEADER, <<"AMQP", 0, 1, 0, 0>>).
 -define(SASL_PROTOCOL_HEADER, <<"AMQP", 3, 1, 0, 0>>).
 -define(MIN_MAX_FRAME_SIZE, 512).
--define(MAX_MAX_FRAME_SIZE, 4294967295).
+-define(MAX_MAX_FRAME_SIZE, 1024 * 1024).
 -define(FRAME_HEADER_SIZE, 8).
 
 

--- a/src/amqp10_client_connection.erl
+++ b/src/amqp10_client_connection.erl
@@ -464,4 +464,5 @@ sasl_to_bin(anon) -> <<"ANONYMOUS">>.
 
 config_defaults() ->
     #{sasl => none,
-      transfer_limit_margin => 0}.
+      transfer_limit_margin => 0,
+      max_frame_size => ?MAX_MAX_FRAME_SIZE}.

--- a/src/amqp10_client_session.erl
+++ b/src/amqp10_client_session.erl
@@ -354,10 +354,10 @@ mapped({#'v1_0.transfer'{handle = {uint, InHandle},
 
     {ok, #link{target = {pid, TargetPid},
                output_handle = OutHandle,
-               ref = LinkRef} = Link} =
+               ref = LinkRef} = Link0} =
         find_link_by_input_handle(InHandle, State0),
 
-    {Transfer, Payload} = complete_partial_transfer(Transfer0, Payload0, Link),
+    {Transfer, Payload, Link} = complete_partial_transfer(Transfer0, Payload0, Link0),
     Msg = decode_as_msg(Transfer, Payload),
 
     % stash the DeliveryId - not sure for what yet
@@ -909,11 +909,12 @@ append_partial_transfer(_Transfer, Payload,
     Link#link{partial_transfers = {T, [Payload | Payloads]}}.
 
 complete_partial_transfer(Transfer, Payload,
-                          #link{partial_transfers = undefined}) ->
-    {Transfer, Payload};
+                          #link{partial_transfers = undefined} = Link) ->
+    {Transfer, Payload, Link};
 complete_partial_transfer(_Transfer, Payload,
-                          #link{partial_transfers = {T, Payloads}}) ->
-    {T, iolist_to_binary(lists:reverse([Payload | Payloads]))}.
+                          #link{partial_transfers = {T, Payloads}} = Link) ->
+    {T, iolist_to_binary(lists:reverse([Payload | Payloads])),
+     Link#link{partial_transfers = undefined}}.
 
 decode_as_msg(Transfer, Payload) ->
     Records = amqp10_framing:decode_bin(Payload),

--- a/test/system_SUITE.erl
+++ b/test/system_SUITE.erl
@@ -84,7 +84,8 @@ shared() ->
      transfer_unsettled,
      subscribe,
      subscribe_with_auto_flow,
-     outgoing_heartbeat
+     outgoing_heartbeat,
+     roundtrip_large_messages
     ].
 
 %% -------------------------------------------------------------------
@@ -299,7 +300,23 @@ basic_roundtrip_service_bus(Config) ->
                 sasl => {plain, User, Password}},
     roundtrip(OpnConf).
 
+roundtrip_large_messages(Config) ->
+    Hostname = ?config(rmq_hostname, Config),
+    Port = rabbit_ct_broker_helpers:get_node_config(Config, 0, tcp_port_amqp),
+    OpenConf = #{address => Hostname, port => Port, sasl => anon},
+    DataKb = crypto:strong_rand_bytes(1024),
+    roundtrip(OpenConf, DataKb),
+    Data1Mb = binary:copy(DataKb, 1024),
+    roundtrip(OpenConf, Data1Mb),
+    roundtrip(OpenConf, binary:copy(Data1Mb, 8)),
+    roundtrip(OpenConf, binary:copy(Data1Mb, 64)),
+    ok.
+
+
 roundtrip(OpenConf) ->
+    roundtrip(OpenConf, <<"banana">>).
+
+roundtrip(OpenConf, Body) ->
     {ok, Connection} = amqp10_client:open_connection(OpenConf),
     {ok, Session} = amqp10_client:begin_session(Connection),
     {ok, Sender} = amqp10_client:attach_sender_link(Session,
@@ -312,8 +329,7 @@ roundtrip(OpenConf) ->
     Now = os:system_time(millisecond),
     Props = #{creation_time => Now},
     Msg0 =  amqp10_msg:set_properties(Props,
-                                      amqp10_msg:new(<<"my-tag">>, <<"banana">>,
-                                                     true)),
+                                      amqp10_msg:new(<<"my-tag">>, Body, true)),
     Msg1 = amqp10_msg:set_application_properties(#{"a_key" => "a_value"}, Msg0),
     Msg = amqp10_msg:set_message_annotations(#{<<"x_key">> => "x_value"}, Msg1),
     % RabbitMQ AMQP 1.0 does not yet support delivery annotations
@@ -328,15 +344,15 @@ roundtrip(OpenConf) ->
                                                         <<"test1">>,
                                                         settled,
                                                         unsettled_state),
-    {ok, OutMsg} = amqp10_client:get_msg(Receiver),
+    {ok, OutMsg} = amqp10_client:get_msg(Receiver, 60000 * 5),
     ok = amqp10_client:end_session(Session),
     ok = amqp10_client:close_connection(Connection),
-    ct:pal(?LOW_IMPORTANCE, "roundtrip message Out: ~p~nIn: ~p~n", [OutMsg, Msg]),
+    % ct:pal(?LOW_IMPORTANCE, "roundtrip message Out: ~p~nIn: ~p~n", [OutMsg, Msg]),
     #{creation_time := Now} = amqp10_msg:properties(OutMsg),
     #{<<"a_key">> := <<"a_value">>} = amqp10_msg:application_properties(OutMsg),
     #{<<"x_key">> := <<"x_value">>} = amqp10_msg:message_annotations(OutMsg),
     % #{<<"x_key">> := <<"x_value">>} = amqp10_msg:delivery_annotations(OutMsg),
-    ?assertEqual([<<"banana">>], amqp10_msg:body(OutMsg)),
+    ?assertEqual([Body], amqp10_msg:body(OutMsg)),
     ok.
 
 % a message is sent before the link attach is guaranteed to
@@ -537,7 +553,7 @@ multi_transfer_without_delivery_id(Config) ->
                                                              % delivery_id can be omitted
                                                              % for continuation frames
                                                              delivery_id = undefined,
-                                                             settled = true,
+                                                             settled = undefined,
                                                              more = false},
                                             #'v1_0.data'{content = <<"world">>}]
                                           ]}}


### PR DESCRIPTION
Set a more sensible default for max_frame_size that works better with
large messages.

Clean up partial transfers on completion.

Fixes #14 