### PR TITLE
Amqp Filters

### DIFF
--- a/src/amqp10_client.erl
+++ b/src/amqp10_client.erl
@@ -244,11 +244,15 @@ attach_receiver_link(Session, Name, Source, SettleMode) ->
                            snd_settle_mode(), terminus_durability()) ->
     {ok, link_ref()}.
 attach_receiver_link(Session, Name, Source, SettleMode, Durability) ->
+    attach_receiver_link(Session, Name, Source, SettleMode, Durability, #{}).
+
+attach_receiver_link(Session, Name, Source, SettleMode, Durability, Filter) ->
     AttachArgs = #{name => Name,
                    role => {receiver, #{address => Source,
                                         durable => Durability}, self()},
                    snd_settle_mode => SettleMode,
-                   rcv_settle_mode => first},
+                   rcv_settle_mode => first,
+                   filter => Filter},
     amqp10_client_session:attach(Session, AttachArgs).
 
 -spec attach_link(pid(), attach_args()) -> {ok, link_ref()}.

--- a/src/amqp10_client.erl
+++ b/src/amqp10_client.erl
@@ -63,6 +63,7 @@
 
 -type attach_role() :: amqp10_client_session:attach_role().
 -type attach_args() :: amqp10_client_session:attach_args().
+-type filter() :: amqp10_client_session:filter().
 
 -type connection_config() :: amqp10_client_connection:connection_config().
 
@@ -246,6 +247,13 @@ attach_receiver_link(Session, Name, Source, SettleMode) ->
 attach_receiver_link(Session, Name, Source, SettleMode, Durability) ->
     attach_receiver_link(Session, Name, Source, SettleMode, Durability, #{}).
 
+%% @doc Attaches a receiver link to a source.
+%% This is asynchronous and will notify completion of the attach request to the
+%% caller using an amqp10_event of the following format:
+%% {amqp10_event, {link, LinkRef, attached | {detached, Why}}}
+-spec attach_receiver_link(pid(), binary(), binary(),
+                           snd_settle_mode(), terminus_durability(), filter()) ->
+    {ok, link_ref()}.
 attach_receiver_link(Session, Name, Source, SettleMode, Durability, Filter) ->
     AttachArgs = #{name => Name,
                    role => {receiver, #{address => Source,

--- a/src/amqp10_client.erl
+++ b/src/amqp10_client.erl
@@ -40,6 +40,7 @@
          attach_receiver_link/3,
          attach_receiver_link/4,
          attach_receiver_link/5,
+         attach_receiver_link/6,
          attach_link/2,
          detach_link/1,
          send_msg/2,

--- a/src/amqp10_client_session.erl
+++ b/src/amqp10_client_session.erl
@@ -657,43 +657,41 @@ translate_terminus_durability(none) -> 0;
 translate_terminus_durability(configuration) -> 1;
 translate_terminus_durability(unsettled_state) -> 2.
 
-translate_filters(#{}) -> undefined;
-translate_filters(Filters) ->
-    {
-        map,
-        maps:fold(
-            fun(<<"apache.org:legacy-amqp-direct-binding:string">> = K, V, Acc) when is_binary(V) ->
-                [{{symbol, K}, {utf8, V}} | Acc];
-            (<<"apache.org:legacy-amqp-topic-binding:string">> = K, V, Acc) when is_binary(V) ->
-                [{{symbol, K}, {utf8, V}} | Acc];
-            (<<"apache.org:legacy-amqp-headers-binding:map">> = K, V, Acc) when is_map(V) ->
-                [{{symbol, K}, translate_legacy_amqp_headers_binding(V)} | Acc];
-            (<<"apache.org:no-local-filter:list">> = K, V, Acc) when is_list(V) ->
-                [{{symbol, K}, lists:map(fun(Id) -> {utf8, Id} end, V)} | Acc];
-            (<<"apache.org:selector-filter:string">> = K, V, Acc) when is_binary(V) ->
-                [{{symbol, K}, {utf8, V}} | Acc]
-            end,
-            [],
-            Filters)
-    }.
+translate_filters(Filters) when is_map(Filters) andalso map_size(Filters) =< 0 -> undefined;
+translate_filters(Filters) when is_map(Filters) -> {
+    map,
+    maps:fold(
+        fun(<<"apache.org:legacy-amqp-direct-binding:string">> = K, V, Acc) when is_binary(V) ->
+            [{{symbol, K}, {utf8, V}} | Acc];
+        (<<"apache.org:legacy-amqp-topic-binding:string">> = K, V, Acc) when is_binary(V) ->
+            [{{symbol, K}, {utf8, V}} | Acc];
+        (<<"apache.org:legacy-amqp-headers-binding:map">> = K, V, Acc) when is_map(V) ->
+            [{{symbol, K}, translate_legacy_amqp_headers_binding(V)} | Acc];
+        (<<"apache.org:no-local-filter:list">> = K, V, Acc) when is_list(V) ->
+            [{{symbol, K}, lists:map(fun(Id) -> {utf8, Id} end, V)} | Acc];
+        (<<"apache.org:selector-filter:string">> = K, V, Acc) when is_binary(V) ->
+            [{{symbol, K}, {utf8, V}} | Acc]
+        end,
+        [],
+        Filters)
+}.
 
 % https://people.apache.org/~rgodfrey/amqp-1.0/apache-filters.html
-translate_legacy_amqp_headers_binding(LegacyHeaders) ->
-    {
-        map,
-        maps:fold(
-            fun(<<"x-match">> = K, <<"any">> = V, Acc) ->
-                [{{utf8, K}, {utf8, V}} | Acc];
-            (<<"x-match">> = K, <<"all">> = V, Acc) ->
-                [{{utf8, K}, {utf8, V}} | Acc];
-            (<<"x-",_/binary>>, _, Acc) ->
-                Acc;
-            (K, V, Acc) ->
-                [{{utf8, K}, {utf8, V}} | Acc]
-            end,
-            [],
-            LegacyHeaders)
-    }.
+translate_legacy_amqp_headers_binding(LegacyHeaders) -> {
+    map,
+    maps:fold(
+        fun(<<"x-match">> = K, <<"any">> = V, Acc) ->
+            [{{utf8, K}, {utf8, V}} | Acc];
+        (<<"x-match">> = K, <<"all">> = V, Acc) ->
+            [{{utf8, K}, {utf8, V}} | Acc];
+        (<<"x-",_/binary>>, _, Acc) ->
+            Acc;
+        (K, V, Acc) ->
+            [{{utf8, K}, {utf8, V}} | Acc]
+        end,
+        [],
+        LegacyHeaders)
+}.
 
 send_detach(Send, {detach, OutHandle}, _From, State = #state{links = Links}) ->
     case Links of
@@ -1064,4 +1062,67 @@ handle_link_flow_receiver_test() ->
     true = Outcome#link.drain,
     SenderDC = Outcome#link.delivery_count. % maintain delivery count
 
+translate_filters_empty_map_test() ->
+    undefined = translate_filters(#{}).
+
+translate_filters_legacy_amqp_direct_binding_filter_test() ->
+    {map,
+        [{
+            {symbol,<<"apache.org:legacy-amqp-direct-binding:string">>},
+            {utf8,<<"my topic">>}
+        }]
+    } = translate_filters(#{<<"apache.org:legacy-amqp-direct-binding:string">> => <<"my topic">>}).
+
+translate_filters_legacy_amqp_topic_binding_filter_test() ->
+    {map,
+        [{
+            {symbol, <<"apache.org:legacy-amqp-topic-binding:string">>},
+            {utf8, <<"*.stock.#">>}
+        }]
+    } = translate_filters(#{<<"apache.org:legacy-amqp-topic-binding:string">> => <<"*.stock.#">>}).
+
+translate_filters_legacy_amqp_headers_binding_filter_test() ->
+    {map,
+        [{
+            {symbol,<<"apache.org:legacy-amqp-headers-binding:map">>},
+            {map, [
+                    {{utf8, <<"x-match">>}, {utf8, <<"all">>}},
+                    {{utf8, <<"foo">>}, {utf8, <<"bar">>}},
+                    {{utf8, <<"bar">>}, {utf8, <<"baz">>}}
+                ]
+            }
+        }]
+    } = translate_filters(#{<<"apache.org:legacy-amqp-headers-binding:map">> => #{
+            <<"x-match">> => <<"all">>,
+            <<"x-something">> => <<"ignored">>,
+            <<"bar">> => <<"baz">>,
+            <<"foo">> => <<"bar">>
+        }}).
+
+translate_filters_legacy_amqp_no_local_filter_test() ->
+    {map,
+        [{
+            {symbol, <<"apache.org:no-local-filter:list">>},
+            [{utf8, <<"foo">>}, {utf8, <<"bar">>}]
+        }]
+    } = translate_filters(#{<<"apache.org:no-local-filter:list">> => [<<"foo">>, <<"bar">>]}).
+
+translate_filters_selector_filter_test() ->
+    {map,
+        [{
+            {symbol, <<"apache.org:selector-filter:string">>},
+            {utf8, <<"amqp.annotation.x-opt-enqueuedtimeutc > 123456789">>}
+        }]
+    } = translate_filters(#{<<"apache.org:selector-filter:string">> => <<"amqp.annotation.x-opt-enqueuedtimeutc > 123456789">>}).
+
+translate_filters_multiple_filters_test() ->
+    {map,
+        [
+            {{symbol, <<"apache.org:selector-filter:string">>}, {utf8, <<"amqp.annotation.x-opt-enqueuedtimeutc > 123456789">>}},
+            {{symbol, <<"apache.org:legacy-amqp-direct-binding:string">>}, {utf8,<<"my topic">>}}
+        ]
+    } = translate_filters(#{
+            <<"apache.org:legacy-amqp-direct-binding:string">> => <<"my topic">>,
+            <<"apache.org:selector-filter:string">> => <<"amqp.annotation.x-opt-enqueuedtimeutc > 123456789">>
+        }).
 -endif.

--- a/src/amqp10_client_session.erl
+++ b/src/amqp10_client_session.erl
@@ -657,28 +657,42 @@ translate_terminus_durability(configuration) -> 1;
 translate_terminus_durability(unsettled_state) -> 2.
 
 translate_filters(#{}) -> undefined;
-translate_filters(Filters) -> {map, maps:fold(fun(<<"apache.org:legacy-amqp-direct-binding:string">> = K, V, Acc) when is_binary(V) ->
-                                                [{{symbol, K}, {utf8, V}} | Acc];
-                                                 (<<"apache.org:legacy-amqp-topic-binding:string">> = K, V, Acc) when is_binary(V) ->
-                                                [{{symbol, K}, {utf8, V}} | Acc];
-                                                 (<<"apache.org:legacy-amqp-headers-binding:map">> = K, V, Acc) when is_map(V) ->
-                                                [{{symbol, K}, translate_legacy_amqp_headers_binding(V)} | Acc];
-                                                 (<<"apache.org:no-local-filter:list">> = K, V, Acc) when is_list(V) ->
-                                                [{{symbol, K}, lists:map(fun(Id) -> {utf8, Id} end, V)} | Acc];
-                                                 (<<"apache.org:selector-filter:string">> = K, V, Acc) when is_binary(V) ->
-                                                [{{symbol, K}, {utf8, V}} | Acc]
-                                              end, [], Filters)}.
+translate_filters(Filters) ->
+    {
+        map,
+        maps:fold(
+            fun(<<"apache.org:legacy-amqp-direct-binding:string">> = K, V, Acc) when is_binary(V) ->
+                [{{symbol, K}, {utf8, V}} | Acc];
+            (<<"apache.org:legacy-amqp-topic-binding:string">> = K, V, Acc) when is_binary(V) ->
+                [{{symbol, K}, {utf8, V}} | Acc];
+            (<<"apache.org:legacy-amqp-headers-binding:map">> = K, V, Acc) when is_map(V) ->
+                [{{symbol, K}, translate_legacy_amqp_headers_binding(V)} | Acc];
+            (<<"apache.org:no-local-filter:list">> = K, V, Acc) when is_list(V) ->
+                [{{symbol, K}, lists:map(fun(Id) -> {utf8, Id} end, V)} | Acc];
+            (<<"apache.org:selector-filter:string">> = K, V, Acc) when is_binary(V) ->
+                [{{symbol, K}, {utf8, V}} | Acc]
+            end,
+            [],
+            Filters)
+    }.
 
 % https://people.apache.org/~rgodfrey/amqp-1.0/apache-filters.html
-translate_legacy_amqp_headers_binding(LegacyHeaders) -> {map, maps:fold(fun(<<"x-match">> = K, <<"any">> = V, Acc) ->
-                                                                            [{{utf8, K}, {utf8, V}} | Acc];
-                                                                           (<<"x-match">> = K, <<"all">> = V, Acc) ->
-                                                                            [{{utf8, K}, {utf8, V}} | Acc];
-                                                                           (<<"x-",_/binary>> = K, _, Acc) ->
-                                                                            Acc;
-                                                                           (K, V, Acc) ->
-                                                                            [{{utf8, K}, {utf8, V}} | Acc]
-                                                                        end, [], LegacyHeaders)}.
+translate_legacy_amqp_headers_binding(LegacyHeaders) ->
+    {
+        map,
+        maps:fold(
+            fun(<<"x-match">> = K, <<"any">> = V, Acc) ->
+                [{{utf8, K}, {utf8, V}} | Acc];
+            (<<"x-match">> = K, <<"all">> = V, Acc) ->
+                [{{utf8, K}, {utf8, V}} | Acc];
+            (<<"x-",_/binary>>, _, Acc) ->
+                Acc;
+            (K, V, Acc) ->
+                [{{utf8, K}, {utf8, V}} | Acc]
+            end,
+            [],
+            LegacyHeaders)
+    }.
 
 send_detach(Send, {detach, OutHandle}, _From, State = #state{links = Links}) ->
     case Links of

--- a/src/amqp10_client_session.erl
+++ b/src/amqp10_client_session.erl
@@ -91,10 +91,15 @@
                         durable => terminus_durability()}.
 
 -type attach_role() :: {sender, target_def()} | {receiver, source_def(), pid()}.
+
+% http://www.amqp.org/specification/1.0/filters
+-type filter() :: #{binary() => binary() | map() | list(binary())}.
+
 -type attach_args() :: #{name => binary(),
                          role => attach_role(),
                          snd_settle_mode => snd_settle_mode(),
-                         rcv_settle_mode => rcv_settle_mode()
+                         rcv_settle_mode => rcv_settle_mode(),
+                         filter => filter()
                         }.
 
 -type link_ref() :: #link_ref{}.
@@ -633,10 +638,12 @@ build_frames(Channel, Trf, Payload, MaxPayloadSize, Acc) ->
 
 make_source(#{role := {sender, _}}) ->
     #'v1_0.source'{};
-make_source(#{role := {receiver, #{address := Address} = Target, _Pid}}) ->
+make_source(#{role := {receiver, #{address := Address} = Target, _Pid}, filter := Filter}) ->
     Durable = translate_terminus_durability(maps:get(durable, Target, none)),
+    TranslatedFilter = translate_filters(Filter),
     #'v1_0.source'{address = {utf8, Address},
-                   durable = {uint, Durable}}.
+                   durable = {uint, Durable},
+                   filter = TranslatedFilter}.
 
 make_target(#{role := {receiver, _Source, _Pid}}) ->
     #'v1_0.target'{};
@@ -648,6 +655,30 @@ make_target(#{role := {sender, #{address := Address} = Target}}) ->
 translate_terminus_durability(none) -> 0;
 translate_terminus_durability(configuration) -> 1;
 translate_terminus_durability(unsettled_state) -> 2.
+
+translate_filters(#{}) -> undefined;
+translate_filters(Filters) -> {map, maps:fold(fun(<<"apache.org:legacy-amqp-direct-binding:string">> = K, V, Acc) when is_binary(V) ->
+                                                [{{symbol, K}, {utf8, V}} | Acc];
+                                                 (<<"apache.org:legacy-amqp-topic-binding:string">> = K, V, Acc) when is_binary(V) ->
+                                                [{{symbol, K}, {utf8, V}} | Acc];
+                                                 (<<"apache.org:legacy-amqp-headers-binding:map">> = K, V, Acc) when is_map(V) ->
+                                                [{{symbol, K}, translate_legacy_amqp_headers_binding(V)} | Acc];
+                                                 (<<"apache.org:no-local-filter:list">> = K, V, Acc) when is_list(V) ->
+                                                [{{symbol, K}, lists:map(fun(Id) -> {utf8, Id} end, V)} | Acc];
+                                                 (<<"apache.org:selector-filter:string">> = K, V, Acc) when is_binary(V) ->
+                                                [{{symbol, K}, {utf8, V}} | Acc]
+                                              end, [], Filters)}.
+
+% https://people.apache.org/~rgodfrey/amqp-1.0/apache-filters.html
+translate_legacy_amqp_headers_binding(LegacyHeaders) -> {map, maps:fold(fun(<<"x-match">> = K, <<"any">> = V, Acc) ->
+                                                                            [{{utf8, K}, {utf8, V}} | Acc];
+                                                                           (<<"x-match">> = K, <<"all">> = V, Acc) ->
+                                                                            [{{utf8, K}, {utf8, V}} | Acc];
+                                                                           (<<"x-",_/binary>> = K, _, Acc) ->
+                                                                            Acc;
+                                                                           (K, V, Acc) ->
+                                                                            [{{utf8, K}, {utf8, V}} | Acc]
+                                                                        end, [], LegacyHeaders)}.
 
 send_detach(Send, {detach, OutHandle}, _From, State = #state{links = Links}) ->
     case Links of

--- a/src/amqp10_client_session.erl
+++ b/src/amqp10_client_session.erl
@@ -110,7 +110,8 @@
               attach_args/0,
               attach_role/0,
               target_def/0,
-              source_def/0]).
+              source_def/0,
+              filter/0]).
 
 -record(link,
         {name :: link_name(),

--- a/test/system_SUITE.erl
+++ b/test/system_SUITE.erl
@@ -402,7 +402,7 @@ filtered_roundtrip(OpenConf, Body) ->
                                                         <<"test1">>,
                                                         settled,
                                                         unsettled_state,
-                                                        #{<<"apache.org:selector-filter:string">> => <<"amqp.annotation.x-opt-enqueuedtimeutc > ", Now2Binary>>}),
+                                                        #{<<"apache.org:selector-filter:string">> => <<"amqp.annotation.x-opt-enqueuedtimeutc > ", Now2Binary/binary>>}),
 
     {ok, OutMsg2} = amqp10_client:get_msg(DefaultReceiver, 60000 * 5),
     ?assertEqual(<<"msg-2-tag">>, amqp10_msg:delivery_tag(OutMsg2)),

--- a/test/system_SUITE.erl
+++ b/test/system_SUITE.erl
@@ -66,7 +66,8 @@ groups() ->
       ]},
       {azure, [],
       [
-       basic_roundtrip_service_bus
+       basic_roundtrip_service_bus,
+       filtered_roundtrip_service_bus
       ]},
      {mock, [], [
                  insufficient_credit,
@@ -286,19 +287,24 @@ basic_roundtrip_tls(Config) ->
                 sasl => ?config(sasl, Config)},
     roundtrip(OpnConf).
 
-basic_roundtrip_service_bus(Config) ->
+service_bus_config(Config, ContainerId) ->
     Hostname = ?config(sb_endpoint, Config),
     Port = ?config(sb_port, Config),
     User = ?config(sb_keyname, Config),
     Password = ?config(sb_key, Config),
-    OpnConf = #{address => Hostname,
-                hostname => to_bin(Hostname),
-                port => Port,
-                tls_opts => {secure_port, [{versions, ['tlsv1.1']}]},
-                notify => self(),
-                container_id => <<"basic_roundtrip_service_bus">>,
-                sasl => {plain, User, Password}},
-    roundtrip(OpnConf).
+    #{address => Hostname,
+      hostname => to_bin(Hostname),
+      port => Port,
+      tls_opts => {secure_port, [{versions, ['tlsv1.1']}]},
+      notify => self(),
+      container_id => ContainerId,
+      sasl => {plain, User, Password}}.
+
+basic_roundtrip_service_bus(Config) ->
+    roundtrip(service_bus_config(Config, <<"basic_roundtrip_service_bus">>)).
+
+filtered_roundtrip_service_bus(Config) ->
+    filtered_roundtrip(service_bus_config(Config, <<"filtered_roundtrip_service_bus">>)).
 
 roundtrip_large_messages(Config) ->
     Hostname = ?config(rmq_hostname, Config),
@@ -353,6 +359,59 @@ roundtrip(OpenConf, Body) ->
     #{<<"x_key">> := <<"x_value">>} = amqp10_msg:message_annotations(OutMsg),
     % #{<<"x_key">> := <<"x_value">>} = amqp10_msg:delivery_annotations(OutMsg),
     ?assertEqual([Body], amqp10_msg:body(OutMsg)),
+    ok.
+
+filtered_roundtrip(OpenConf) ->
+    filtered_roundtrip(OpenConf, <<"banana">>).
+
+filtered_roundtrip(OpenConf, Body) ->
+    {ok, Connection} = amqp10_client:open_connection(OpenConf),
+    {ok, Session} = amqp10_client:begin_session(Connection),
+    {ok, Sender} = amqp10_client:attach_sender_link(Session,
+                                                    <<"default-sender">>,
+                                                    <<"test1">>,
+                                                    settled,
+                                                    unsettled_state),
+    await_link(Sender, credited, link_credit_timeout),
+
+    Now = os:system_time(millisecond),
+    Props1 = #{creation_time => Now},
+    Msg1 = amqp10_msg:set_properties(Props1, amqp10_msg:new(<<"msg-1-tag">>, Body, true)),
+    ok = amqp10_client:send_msg(Sender, Msg1),
+
+    {ok, DefaultReceiver} = amqp10_client:attach_receiver_link(Session,
+                                                        <<"default-receiver">>,
+                                                        <<"test1">>,
+                                                        settled,
+                                                        unsettled_state),
+    ok = amqp10_client:send_msg(Sender, Msg1),
+    {ok, OutMsg1} = amqp10_client:get_msg(DefaultReceiver, 60000 * 5),
+    ?assertEqual(<<"msg-1-tag">>, amqp10_msg:delivery_tag(OutMsg1)),
+
+    timer:sleep(5 * 1000),
+
+    Now2 = os:system_time(millisecond),
+    Props2 = #{creation_time => Now2 - 1000},
+    Msg2 = amqp10_msg:set_properties(Props2, amqp10_msg:new(<<"msg-2-tag">>, Body, true)),
+    Now2Binary = integer_to_binary(Now2),
+
+    ok = amqp10_client:send_msg(Sender, Msg2),
+
+    {ok, FilteredReceiver} = amqp10_client:attach_receiver_link(Session,
+                                                        <<"filtered-receiver">>,
+                                                        <<"test1">>,
+                                                        settled,
+                                                        unsettled_state,
+                                                        #{<<"apache.org:selector-filter:string">> => <<"amqp.annotation.x-opt-enqueuedtimeutc > ", Now2Binary>>}),
+
+    {ok, OutMsg2} = amqp10_client:get_msg(DefaultReceiver, 60000 * 5),
+    ?assertEqual(<<"msg-2-tag">>, amqp10_msg:delivery_tag(OutMsg2)),
+
+    {ok, OutMsgFiltered} = amqp10_client:get_msg(FilteredReceiver, 60000 * 5),
+    ?assertEqual(<<"msg-2-tag">>, amqp10_msg:delivery_tag(OutMsgFiltered)),
+
+    ok = amqp10_client:end_session(Session),
+    ok = amqp10_client:close_connection(Connection),
     ok.
 
 % a message is sent before the link attach is guaranteed to


### PR DESCRIPTION
This PR adds the Amqp Filter functionality #3 to the client. Upon attaching a receiver link one can pass a map of filters.

So far I have only written a test for Azure but all the other tests are green so no existing functionality is negatively affected.

Let me know what you think. I need this functionality for an upcoming project which connects to Azure Eventhubs and since people have asked for the ability to set filters I thought it would be a good time to implement them.