### PR TITLE
Add support for AMQP properties

### DIFF
--- a/src/amqp10_client.erl
+++ b/src/amqp10_client.erl
@@ -271,7 +271,6 @@ attach_receiver_link(Session, Name, Source, SettleMode, Durability, Filter) ->
                            properties()) ->
     {ok, link_ref()}.
 attach_receiver_link(Session, Name, Source, SettleMode, Durability, Filter, Properties) ->
-    io:format(user, "~nat=~s:~p:~p", [?MODULE_STRING, ?FUNCTION_NAME, ?LINE]),
     AttachArgs = #{name => Name,
                    role => {receiver, #{address => Source,
                                         durable => Durability}, self()},

--- a/src/amqp10_client.erl
+++ b/src/amqp10_client.erl
@@ -41,6 +41,7 @@
          attach_receiver_link/4,
          attach_receiver_link/5,
          attach_receiver_link/6,
+         attach_receiver_link/7,
          attach_link/2,
          detach_link/1,
          send_msg/2,
@@ -67,6 +68,7 @@
 -type attach_role() :: amqp10_client_session:attach_role().
 -type attach_args() :: amqp10_client_session:attach_args().
 -type filter() :: amqp10_client_session:filter().
+-type properties() :: amqp10_client_session:properties().
 
 -type connection_config() :: amqp10_client_connection:connection_config().
 
@@ -258,12 +260,25 @@ attach_receiver_link(Session, Name, Source, SettleMode, Durability) ->
                            snd_settle_mode(), terminus_durability(), filter()) ->
     {ok, link_ref()}.
 attach_receiver_link(Session, Name, Source, SettleMode, Durability, Filter) ->
+    attach_receiver_link(Session, Name, Source, SettleMode, Durability, Filter, #{}).
+
+%% @doc Attaches a receiver link to a source.
+%% This is asynchronous and will notify completion of the attach request to the
+%% caller using an amqp10_event of the following format:
+%% {amqp10_event, {link, LinkRef, attached | {detached, Why}}}
+-spec attach_receiver_link(pid(), binary(), binary(),
+                           snd_settle_mode(), terminus_durability(), filter(),
+                           properties()) ->
+    {ok, link_ref()}.
+attach_receiver_link(Session, Name, Source, SettleMode, Durability, Filter, Properties) ->
+    io:format(user, "~nat=~s:~p:~p", [?MODULE_STRING, ?FUNCTION_NAME, ?LINE]),
     AttachArgs = #{name => Name,
                    role => {receiver, #{address => Source,
                                         durable => Durability}, self()},
                    snd_settle_mode => SettleMode,
                    rcv_settle_mode => first,
-                   filter => Filter},
+                   filter => Filter,
+                   properties => Properties},
     amqp10_client_session:attach(Session, AttachArgs).
 
 -spec attach_link(pid(), attach_args()) -> {ok, link_ref()}.

--- a/src/amqp10_client_session.erl
+++ b/src/amqp10_client_session.erl
@@ -666,15 +666,7 @@ translate_properties(Properties) when is_map(Properties) ->
     {map, maps:fold(fun translate_property/3, [], Properties)}.
 
 translate_property(K, V, Acc) when is_tuple(V) ->
-    io:format(user, "~nat=~s:~p:~p key=~p value=~p", [?MODULE_STRING, ?FUNCTION_NAME, ?LINE, K, V]),
-    [{{symbol, K}, {described, {symbol, K}, V}} | Acc];
-translate_property(K, V, Acc) when is_binary(V) ->
-    [{{symbol, K}, {described, {symbol, K}, {utf8, V}}} | Acc];
-translate_property(K, V, Acc) when is_integer(V) ->
-    [{{symbol, K}, {described, {symbol, K}, {long, V}}} | Acc];
-translate_property(K, V, Acc) when is_list(V) ->
-    Values = lists:map(fun(Id) -> {utf8, Id} end, V),
-    [{{symbol, K}, {described, {symbol, K}, Values}} | Acc].
+    [{{symbol, K}, V} | Acc].
 
 translate_terminus_durability(none) -> 0;
 translate_terminus_durability(configuration) -> 1;

--- a/src/amqp10_client_session.erl
+++ b/src/amqp10_client_session.erl
@@ -94,7 +94,7 @@
 
 % http://www.amqp.org/specification/1.0/filters
 -type filter() :: #{binary() => binary() | map() | list(binary())}.
--type properties() :: #{binary() => binary() | list(binary())}.
+-type properties() :: #{binary() => tuple()}.
 
 -type attach_args() :: #{name => binary(),
                          role => attach_role(),


### PR DESCRIPTION
The specification says that the `attach` request can specify [`properties`](http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-transport-v1.0-os.html#type-attach). This PR adds support for those.

I wasn't sure how to support the multiple integer types so I left the responsability of specifiying the AMQP type to the user of the library.