### PR TITLE
amqp10_client_connection: Handle heartbeat in close_sent/2

### DIFF
--- a/src/amqp10_client_connection.erl
+++ b/src/amqp10_client_connection.erl
@@ -257,6 +257,8 @@ opened(Frame, State) ->
                              [Frame, State]),
     {next_state, opened, State}.
 
+close_sent(heartbeat, State) ->
+    {next_state, close_sent, State};
 close_sent(#'v1_0.close'{}, State) ->
     % TODO: we should probably set up a timer before this to ensure
     % we close down event if no reply is received


### PR DESCRIPTION
This message, sent by the timer module, may happen in the `close_sent` state. We can ignore it but we still need to handle it.

I saw this case happen in CI:

```
*** System report during system_SUITE:init_per_group/2 for activemq 2020-02-12 06:06:06.473 ***
=WARNING REPORT==== 12-Feb-2020::06:06:06.473178 ===
terminating connection with reason '{function_clause,
                                     [{amqp10_client_connection,close_sent,
                                       [heartbeat,
                                        {state,2,<0.455.0>,
(...)
```