### PR TITLE
sasl_outcome supports more error codes

### DIFF
--- a/src/amqp10_client_connection.erl
+++ b/src/amqp10_client_connection.erl
@@ -199,8 +199,8 @@ sasl_init_sent(#'v1_0.sasl_outcome'{code = {ubyte, 0}},
                #state{socket = Socket} = State) ->
     ok = socket_send(Socket, ?AMQP_PROTOCOL_HEADER),
     {next_state, hdr_sent, State};
-sasl_init_sent(#'v1_0.sasl_outcome'{code = {ubyte, 1}},
-               #state{} = State) ->
+sasl_init_sent(#'v1_0.sasl_outcome'{code = {ubyte, C}},
+               #state{} = State) when C==1;C==2;C==3;C==4 ->
     {stop, sasl_auth_failure, State}.
 
 hdr_sent({protocol_header_received, 0, 1, 0, 0}, State) ->


### PR DESCRIPTION
sasl_outcome currently supports only code = 0 or 1
This fix makes sure sasl_outcome supports all codes from the AMQP10 specification

Otherwise rabbitmq-amqp1.0-client crashes with: 
        ** (FunctionClauseError) no function clause matching in :amqp10_client_connection.sasl_init_sent/2
            (amqp10_client 0.0.0) src/amqp10_client_connection.erl:198: :amqp10_client_connection.sasl_init_sent({:"v1_0.sasl_outcome", {:ubyte, 2}, :undefined}, {:state, 1, #PID<0.5204.0>, #Reference<0.1566087877.927203329.110289>, #PID ...